### PR TITLE
[CI] Drop warnings for react rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,10 +20,10 @@
     ],
     "rules": {
         "no-unused-vars": "warn",
-        "react/display-name": "warn",
-        "react/prop-types": "warn",
-        "react/react-in-jsx-scope": "warn",
-        "semi": "warn"
+        "react/display-name": 0,
+        "react/prop-types": 0,
+        "react/react-in-jsx-scope": 0,
+        "semi": ["warn", "never"]
     },
     "settings": {
         "react": {


### PR DESCRIPTION
continue to warn for `no-unused-vars` and `semi`

Fixes #50