### PR TITLE
feat: add booster logic

### DIFF
--- a/src/interactions/Booster.js
+++ b/src/interactions/Booster.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { useStore } from '../store'
+
+const Booster = ({ refBooster }) => {
+  const raycast = useStore((state) => state.raycast)
+  const set = useStore((state) => state.set)
+
+  useEffect(() => {
+    set({ raycast: { ...raycast, boosters: [refBooster.current] } })
+  }, [])
+
+  return null
+}
+
+export default Booster

--- a/src/models/vehicle/Vehicle.js
+++ b/src/models/vehicle/Vehicle.js
@@ -10,6 +10,7 @@ import { Dust } from '../../effects/Dust'
 import { Skid } from '../../effects/Skid'
 
 const v = new THREE.Vector3()
+const rayDownDirection = new THREE.Vector3(0, -1, 0).normalize()
 
 export function Vehicle({ angularVelocity = [0, 0.5, 0], children, position = [0, 4, 0], rotation = [0, Math.PI / 2, 0] }) {
   const defaultCamera = useRef()
@@ -71,6 +72,18 @@ export function Vehicle({ angularVelocity = [0, 0.5, 0], children, position = [0
       (-steeringValue * speed) / 200,
       delta * 4,
     )
+
+    // check booster interaction
+    const rayOrigin = raycast.chassisBody.current.position
+
+    raycast.instance.set(rayOrigin, rayDownDirection)
+
+    const objectsToTest = raycast.boosters
+    const intersects = raycast.instance.intersectObjects(objectsToTest)
+    const isBoosted = intersects.length > 0
+    if (isBoosted !== boost) {
+      set((state) => ({ ...state, controls: { ...state.controls, boost: isBoosted } }))
+    }
   })
 
   return (

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,7 @@
 import { createRef } from 'react'
 import create from 'zustand'
 import { camera } from './enums.js'
+import * as THREE from 'three'
 
 const vehicleConfig = {
   radius: 0.35,
@@ -63,9 +64,11 @@ const useStore = create((set, get) => {
     help: false,
     debug: false,
     raycast: {
+      instance: new THREE.Raycaster(),
       chassisBody: createRef(),
       wheels: [createRef(), createRef(), createRef(), createRef()],
       wheelInfos: [wheelInfo1, wheelInfo2, wheelInfo3, wheelInfo4],
+      boosters: [],
       indexForwardAxis: 2,
       indexRightAxis: 0,
       indexUpAxis: 1,


### PR DESCRIPTION
This is a feature proposal to add **boost area** to the map.

![booster](https://user-images.githubusercontent.com/530644/120896811-67a5b480-c623-11eb-8c44-41ea4ab4a946.png)

This PR only handle the logic part. By casting a ray below the car we check if there is a collision with a booster to activate the flag in the store.

To make an element a booster we would just need to drop the `<Booster />` component into it.

Next PR:
- add booster model and place them on the map
- add new visual effect while the car is boosted?