### PR TITLE
Improve performance with canvas

### DIFF
--- a/src/models/track/Heightmap.js
+++ b/src/models/track/Heightmap.js
@@ -39,6 +39,15 @@ function HeightmapGeometry({ heights, elementSize, ...rest }) {
 
 extend({ HeightmapGeometry })
 
+let canvas
+let context
+
+function createCanvas() {
+  canvas = document.createElement('canvas')
+  context = canvas.getContext('2d')
+  context.imageSmoothingEnabled = false
+}
+
 /**
  * Returns matrix data to be passed to heightfield.
  * set elementSize as `size` / matrix[0].length (image width)
@@ -47,27 +56,29 @@ extend({ HeightmapGeometry })
  * @returns {[[Number]]} height data extracted from image
  */
 function createHeightfieldMatrix(image) {
+  if (!canvas) {
+    createCanvas()
+  }
   let matrix = []
-  const w = image.width
-  const h = image.height
-  const canvas = document.createElement('canvas')
-  const ctx = canvas.getContext('2d')
+  const width = image.width
+  const height = image.height
   const scale = 40 // determines the vertical scale of the heightmap
   let p, row
 
-  canvas.width = w
-  canvas.height = h
-  ctx.drawImage(image, 0, 0, w, h)
-
-  for (let x = 0; x < w; x++) {
+  canvas.width = width
+  canvas.height = height
+  context.drawImage(image, 0, 0, width, height)
+  const imageData = context.getImageData(0, 0, width, height).data
+  for (let x = 0; x < width; x++) {
     row = []
-    for (let y = 0; y < h; y++) {
+    for (let y = 0; y < height; y++) {
       // returned pixel data is [r, g, b, alpha], since image is in b/w -> any rgb val
-      p = Math.max(0, parseFloat((ctx.getImageData(x, y, 1, 1).data[0] / 255).toPrecision(1)) * scale)
+      p = Math.max(0, parseFloat((imageData[4 * (y * width + x)] / 255).toPrecision(1)) * scale)
       row.push(p)
     }
     matrix.push(row)
   }
+  context.clearRect(0, 0, width, height)
   return matrix
 }
 


### PR DESCRIPTION
Canvas can be very bad on performance when used the _wrong_/not optimized way as being noted in #35 it added 10 seconds of loading whereby this should be around 0.2-0.5 seconds and can be improved further but this focused on the way that the canvas was being used.

It will now re-use the canvas(I'm not sure if the heightmap is further in the game being executed again, but if so it will definitely be a good call). 
Disable image smoothing.
Only call the expensive getImageData once.
Do a little bit of maths to get the correct pixel value.

Before (3.2 seconds) https://share.firefox.dev/3ijocx6:
![image](https://user-images.githubusercontent.com/25481501/120901062-0c29f580-c628-11eb-897e-5c121d19295b.png)

After (0.18 seconds) https://share.firefox.dev/3vRoM9g:
![image](https://user-images.githubusercontent.com/25481501/120901077-1f3cc580-c628-11eb-88ca-51bfcda36327.png)

