### PR TITLE
Add option to toggle statsMeter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Canvas } from '@react-three/fiber'
 import { Physics } from '@react-three/cannon'
-import { Sky, Environment, OrbitControls } from '@react-three/drei'
+import { Sky, Environment, OrbitControls, Stats } from '@react-three/drei'
 import { Editor } from './ui/Editor'
 import { useStore } from './store'
 import { Ramp, Track, Vehicle } from './models'
@@ -14,6 +14,7 @@ import { KeyboardControls } from './controls/KeyboardControls'
 export function App() {
   const [light, setLight] = useState()
   const editor = useStore((state) => state.editor)
+  const statsMeter = useStore((state) => state.statsMeter)
   return (
     <Overlay>
       <Canvas dpr={[1, 1.5]} shadows camera={{ position: [0, 5, 15], fov: 50 }}>
@@ -48,6 +49,7 @@ export function App() {
       <Help />
       <KeyboardControls />
       {editor && <Editor />}
+      {statsMeter && <Stats />}
     </Overlay>
   )
 }

--- a/src/ui/Editor.js
+++ b/src/ui/Editor.js
@@ -278,6 +278,7 @@ export function Editor() {
       },
     },
     debug: { value: false, onChange: (debug) => set({ debug }) },
+    statsMeter: { value: false, onChange: (statsMeter) => set({ statsMeter }) },
   }))
   return null
 }


### PR DESCRIPTION
This should be useful to check the current FPS and how long it take to render 1 frame. Going to be a life-saver in the long term to improve performance

It's using the JSX element from Drei: https://github.com/pmndrs/drei/tree/master/#stats

How it looks:
![image](https://user-images.githubusercontent.com/25481501/120902909-79db1f00-c632-11eb-8355-0f029eadb6d8.png)
