### PR TITLE
Fix npm install build fail

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,3 +1,4 @@
+const { join, resolve } = require('path')
 const CracoEsbuildPlugin = require('craco-esbuild')
 const { ProvidePlugin } = require('webpack')
 
@@ -9,5 +10,12 @@ module.exports = {
       }),
     ],
   },
-  plugins: [{ plugin: CracoEsbuildPlugin }],
+  plugins: [
+    {
+      options: {
+        includePaths: [resolve(join('.', 'node_modules'))],
+      },
+      plugin: CracoEsbuildPlugin,
+    },
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "prettier": "2.3.1",
     "react-scripts": "4.0.3"
   },
-  "resolutions": {
-    "acorn": "8.3.0"
-  },
   "scripts": {
     "start": "craco start",
     "build": "craco build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,7 +2464,17 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
-acorn@8.3.0, acorn@^6.4.1, acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0, acorn@^8.2.4:
+acorn@^6.4.1:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
+
+acorn@^7.1.0, acorn@^7.1.1, acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.2.4:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.3.0.tgz#1193f9b96c4e8232f00b11a9edff81b2c8b98b88"
   integrity sha512-tqPKHZ5CaBJw0Xmy0ZZvLs1qTV+BNFSyvn77ASXkpBNfIRk8ev26fKrD9iLGwGA9zedPao52GSHzq8lyZG0NUw==


### PR DESCRIPTION
The workaround for the issue only worked for `yarn` installs.  We should strive to ensure this project works with any package manager.