### PR TITLE
Only play brake sound while braking and drifting

### DIFF
--- a/src/models/vehicle/Vehicle.jsx
+++ b/src/models/vehicle/Vehicle.jsx
@@ -111,7 +111,8 @@ function VehicleAudio() {
     if (honk) {
       if (!honkAudio.current.isPlaying) honkAudio.current.play()
     } else honkAudio.current.isPlaying && honkAudio.current.stop()
-    if ((state.sliding || brake) && state.speed > 5) {
+    if (brake && state.speed > 20) {
+      brakeAudio.current.setVolume((state.speed / 100))
       if (!brakeAudio.current.isPlaying) brakeAudio.current.play()
     } else brakeAudio.current.isPlaying && brakeAudio.current.stop()
   })


### PR DESCRIPTION
* Adjust the threshold speed up to 20, since it gets annoying to hear braking sound whenever you turn
* Adjust volume depending on speed
* Only play sound when drifting or braking

Personally I really like having the extra feedback on drift when navigating tight corners.