### PR TITLE
[Store] Move map out of controls

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ export function App() {
   const [light, setLight] = useState()
   const editor = useStore((state) => state.editor)
   const stats = useStore((state) => state.stats)
-  const map = useStore((state) => state.controls.map)
+  const map = useStore((state) => state.map)
 
   return (
     <Overlay>

--- a/src/controls/Keyboard.js
+++ b/src/controls/Keyboard.js
@@ -52,7 +52,7 @@ export function KeyboardControls() {
       }),
     false,
   )
-  useKeys(['m', 'M'], (toggleMap) => set((state) => ({ ...state, controls: { ...state.controls, map: toggleMap ? !state.controls.map : state.controls.map } })))
+  useKeys(['m', 'M'], () => set((state) => ({ ...state, map: !state.map })), false)
 
   return null
 }

--- a/src/store.js
+++ b/src/store.js
@@ -66,6 +66,7 @@ const useStore = create((set, get) => {
     debug: false,
     stats: false,
     level: createRef(),
+    map: true,
     raycast: {
       chassisBody: createRef(),
       wheels: [createRef(), createRef(), createRef(), createRef()],
@@ -83,7 +84,6 @@ const useStore = create((set, get) => {
       honk: false,
       boost: false,
       reset: false,
-      map: true,
     },
     vehicleConfig,
     velocity: [0, 0, 0],


### PR DESCRIPTION
Similar to `camera`, `map` is not a control, it's a state.