### PR TITLE
fix(help): change "Toggle Mute" key from 's' to 'u'

### DIFF
--- a/src/controls/Keyboard.js
+++ b/src/controls/Keyboard.js
@@ -85,7 +85,7 @@ export function KeyboardControls() {
       up: false,
     },
     {
-      keys: ['s', 'S'],
+      keys: ['u', 'U'],
       fn: () => set((state) => ({ ...state, sound: !state.sound })),
       up: false,
     },

--- a/src/ui/Help.jsx
+++ b/src/ui/Help.jsx
@@ -12,7 +12,7 @@ const controlOptions = [
   { keys: ['C'], action: 'Toggle Camera' },
   { keys: ['R'], action: 'Reset' },
   { keys: ['E'], action: 'Editor' },
-  { keys: ['S'], action: 'Sound' },
+  { keys: ['U'], action: 'Toggle Mute' },
   { keys: ['I'], action: 'Help' },
 ]
 


### PR DESCRIPTION
Since the `s` key is used for going backwards, I've moved the key to toggle the audio to `u`