### PR TITLE
Change editor shortcut

### DIFF
--- a/src/controls/Keyboard.js
+++ b/src/controls/Keyboard.js
@@ -42,10 +42,19 @@ export function Keyboard() {
     { keys: [' '], fn: (brake) => set((state) => ({ ...state, controls: { ...state.controls, brake } })) },
     { keys: ['h', 'H'], fn: (honk) => set((state) => ({ ...state, controls: { ...state.controls, honk } })) },
     { keys: ['Shift'], fn: (boost) => set((state) => ({ ...state, controls: { ...state.controls, boost } })) },
+<<<<<<< HEAD
     { keys: ['r', 'R'], fn: () => reset(set), up: false },
     { keys: ['e', 'E'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
     { keys: ['i', 'I'], fn: () => set((state) => ({ ...state, help: !state.help, leaderboard: false })), up: false },
     { keys: ['l', 'L'], fn: () => set((state) => ({ ...state, help: false, leaderboard: !state.leaderboard })), up: false },
+=======
+    {
+      keys: ['r', 'R'],
+      fn: (reset) => set((state) => ((mutation.start = 0), (mutation.finish = 0), { ...state, finished: false, controls: { ...state.controls, reset } })),
+    },
+    { keys: ['/'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
+    { keys: ['i', 'I'], fn: () => set((state) => ({ ...state, help: !state.help })), up: false },
+>>>>>>> Switch to backslash
     { keys: ['m', 'M'], fn: () => set((state) => ({ ...state, map: !state.map })), up: false },
     { keys: ['u', 'U'], fn: () => set((state) => ({ ...state, sound: !state.sound })), up: false },
     {

--- a/src/controls/Keyboard.js
+++ b/src/controls/Keyboard.js
@@ -52,7 +52,7 @@ export function Keyboard() {
       keys: ['r', 'R'],
       fn: (reset) => set((state) => ((mutation.start = 0), (mutation.finish = 0), { ...state, finished: false, controls: { ...state.controls, reset } })),
     },
-    { keys: ['/'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
+    { keys: ['.'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
     { keys: ['i', 'I'], fn: () => set((state) => ({ ...state, help: !state.help })), up: false },
 >>>>>>> Switch to backslash
     { keys: ['m', 'M'], fn: () => set((state) => ({ ...state, map: !state.map })), up: false },

--- a/src/controls/Keyboard.js
+++ b/src/controls/Keyboard.js
@@ -42,19 +42,10 @@ export function Keyboard() {
     { keys: [' '], fn: (brake) => set((state) => ({ ...state, controls: { ...state.controls, brake } })) },
     { keys: ['h', 'H'], fn: (honk) => set((state) => ({ ...state, controls: { ...state.controls, honk } })) },
     { keys: ['Shift'], fn: (boost) => set((state) => ({ ...state, controls: { ...state.controls, boost } })) },
-<<<<<<< HEAD
     { keys: ['r', 'R'], fn: () => reset(set), up: false },
-    { keys: ['e', 'E'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
+    { keys: ['.'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
     { keys: ['i', 'I'], fn: () => set((state) => ({ ...state, help: !state.help, leaderboard: false })), up: false },
     { keys: ['l', 'L'], fn: () => set((state) => ({ ...state, help: false, leaderboard: !state.leaderboard })), up: false },
-=======
-    {
-      keys: ['r', 'R'],
-      fn: (reset) => set((state) => ((mutation.start = 0), (mutation.finish = 0), { ...state, finished: false, controls: { ...state.controls, reset } })),
-    },
-    { keys: ['.'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
-    { keys: ['i', 'I'], fn: () => set((state) => ({ ...state, help: !state.help })), up: false },
->>>>>>> Switch to backslash
     { keys: ['m', 'M'], fn: () => set((state) => ({ ...state, map: !state.map })), up: false },
     { keys: ['u', 'U'], fn: () => set((state) => ({ ...state, sound: !state.sound })), up: false },
     {

--- a/src/ui/Help.jsx
+++ b/src/ui/Help.jsx
@@ -11,7 +11,7 @@ const controlOptions = [
   { keys: ['M'], action: 'Map' },
   { keys: ['C'], action: 'Toggle Camera' },
   { keys: ['R'], action: 'Reset' },
-  { keys: ['/'], action: 'Editor' },
+  { keys: ['.'], action: 'Editor' },
   { keys: ['U'], action: 'Toggle Mute' },
   { keys: ['I'], action: 'Help' },
   { keys: ['L'], action: 'Leaderboards' },

--- a/src/ui/Help.jsx
+++ b/src/ui/Help.jsx
@@ -11,7 +11,7 @@ const controlOptions = [
   { keys: ['M'], action: 'Map' },
   { keys: ['C'], action: 'Toggle Camera' },
   { keys: ['R'], action: 'Reset' },
-  { keys: ['E'], action: 'Editor' },
+  { keys: ['`'], action: 'Editor' },
   { keys: ['U'], action: 'Toggle Mute' },
   { keys: ['I'], action: 'Help' },
   { keys: ['L'], action: 'Leaderboards' },

--- a/src/ui/Help.jsx
+++ b/src/ui/Help.jsx
@@ -11,7 +11,7 @@ const controlOptions = [
   { keys: ['M'], action: 'Map' },
   { keys: ['C'], action: 'Toggle Camera' },
   { keys: ['R'], action: 'Reset' },
-  { keys: ['`'], action: 'Editor' },
+  { keys: ['/'], action: 'Editor' },
   { keys: ['U'], action: 'Toggle Mute' },
   { keys: ['I'], action: 'Help' },
   { keys: ['L'], action: 'Leaderboards' },


### PR DESCRIPTION
`e` is too close to WASD - it's easy to fat-finger into the editor. Especially frustrating if you are about to beat the leaderboards :) Changed to backtick ( ` ) but open to other suggestions.