### PR TITLE
chore: migrate to valtio state

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
     "extends": [
         "prettier",
         "plugin:react/recommended",
-        "eslint:recommended"
+        "eslint:recommended",
+        "plugin:valtio/recommended"
     ],
     "overrides": [{
         "files": ["*.jsx", "*.js"]

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "three": "0.129.0",
-    "zustand": "^3.5.2"
+    "valtio": "^1.0.6"
   },
   "devDependencies": {
     "@vitejs/plugin-react-refresh": "^1.3.3",
     "eslint": "7.28.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-react": "7.24.0",
+    "eslint-plugin-valtio": "^0.3.1",
     "husky": "^6.0.0",
     "lint-staged": "^11.0.0",
     "prettier": "2.3.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,8 @@ import { Layers } from 'three'
 import { Canvas } from '@react-three/fiber'
 import { Physics, Debug } from '@react-three/cannon'
 import { Sky, Environment, PerspectiveCamera, OrthographicCamera, OrbitControls, Stats } from '@react-three/drei'
-import { angularVelocity, levelLayer, position, rotation, useStore } from './store'
+import { useSnapshot } from 'valtio'
+import { angularVelocity, levelLayer, position, rotation, gameState } from './store'
 import { Ramp, Track, Vehicle, Goal, Train, Heightmap } from './models'
 import { Clock, Speed, Minimap, Intro, Help, Editor, LeaderBoard, Finished } from './ui'
 import { HideMouse, Keyboard } from './controls'
@@ -12,13 +13,13 @@ const layers = new Layers()
 layers.enable(levelLayer)
 
 function DebugScene({ children }) {
-  const debug = useStore((state) => state.debug)
+  const { debug } = useSnapshot(gameState)
   return debug ? <Debug scale={1.0001} color="white" children={children} /> : children
 }
 
 export function App() {
   const [light, setLight] = useState()
-  const [shadows, dpr, camera, editor, map, finished, stats] = useStore((s) => [s.shadows, s.dpr, s.camera, s.editor, s.map, s.finished, s.stats])
+  const { shadows, dpr, camera, editor, map, finished, stats } = useSnapshot(gameState)
   return (
     <Intro>
       <Canvas key={shadows + dpr} mode="concurrent" dpr={[1, dpr]} shadows={shadows} camera={{ position: [0, 5, 15], fov: 50 }}>

--- a/src/controls/Keyboard.js
+++ b/src/controls/Keyboard.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { cameras, reset, useStore } from '../store'
+import { cameras, reset, gameState } from '../store'
 
 function useKeys(keyConfig) {
   useEffect(() => {
@@ -33,24 +33,39 @@ function useKeys(keyConfig) {
 }
 
 export function Keyboard() {
-  const set = useStore((state) => state.set)
   useKeys([
-    { keys: ['ArrowUp', 'w', 'W'], fn: (forward) => set((state) => ({ ...state, controls: { ...state.controls, forward } })) },
-    { keys: ['ArrowDown', 's', 'S'], fn: (backward) => set((state) => ({ ...state, controls: { ...state.controls, backward } })) },
-    { keys: ['ArrowLeft', 'a', 'A'], fn: (left) => set((state) => ({ ...state, controls: { ...state.controls, left } })) },
-    { keys: ['ArrowRight', 'd', 'D'], fn: (right) => set((state) => ({ ...state, controls: { ...state.controls, right } })) },
-    { keys: [' '], fn: (brake) => set((state) => ({ ...state, controls: { ...state.controls, brake } })) },
-    { keys: ['h', 'H'], fn: (honk) => set((state) => ({ ...state, controls: { ...state.controls, honk } })) },
-    { keys: ['Shift'], fn: (boost) => set((state) => ({ ...state, controls: { ...state.controls, boost } })) },
-    { keys: ['r', 'R'], fn: () => reset(set), up: false },
-    { keys: ['e', 'E'], fn: () => set((state) => ({ ...state, editor: !state.editor })), up: false },
-    { keys: ['i', 'I'], fn: () => set((state) => ({ ...state, help: !state.help, leaderboard: false })), up: false },
-    { keys: ['l', 'L'], fn: () => set((state) => ({ ...state, help: false, leaderboard: !state.leaderboard })), up: false },
-    { keys: ['m', 'M'], fn: () => set((state) => ({ ...state, map: !state.map })), up: false },
-    { keys: ['u', 'U'], fn: () => set((state) => ({ ...state, sound: !state.sound })), up: false },
+    { keys: ['ArrowUp', 'w', 'W'], fn: (forward) => void (gameState.controls.forward = forward) },
+    { keys: ['ArrowDown', 's', 'S'], fn: (backward) => void (gameState.controls.backward = backward) },
+    { keys: ['ArrowLeft', 'a', 'A'], fn: (left) => void (gameState.controls.left = left) },
+    { keys: ['ArrowRight', 'd', 'D'], fn: (right) => void (gameState.controls.right = right) },
+    { keys: [' '], fn: (brake) => void (gameState.controls.brake = brake) },
+    { keys: ['h', 'H'], fn: (honk) => void (gameState.controls.honk = honk) },
+    { keys: ['Shift'], fn: (boost) => void (gameState.controls.boost = boost) },
+    { keys: ['r', 'R'], fn: () => reset(), up: false },
+    { keys: ['e', 'E'], fn: () => void (gameState.editor = !gameState.editor), up: false },
+    {
+      keys: ['i', 'I'],
+      fn: () => {
+        gameState.help = !gameState.help
+        gameState.leaderboard = false
+      },
+      up: false,
+    },
+    {
+      keys: ['l', 'L'],
+      fn: () => {
+        gameState.help = false
+        gameState.leaderboard = !gameState.leaderboard
+      },
+      up: false,
+    },
+    { keys: ['m', 'M'], fn: () => void (gameState.map = !gameState.map), up: false },
+    { keys: ['u', 'U'], fn: () => void (gameState.sound = !gameState.sound), up: false },
     {
       keys: ['c', 'C'],
-      fn: () => set((state) => ({ ...state, camera: cameras[(cameras.indexOf(state.camera) + 1) % cameras.length] })),
+      fn: () => {
+        gameState.camera = cameras[(cameras.indexOf(gameState.camera) + 1) % cameras.length]
+      },
       up: false,
     },
   ])

--- a/src/effects/Dust.jsx
+++ b/src/effects/Dust.jsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
-import { useStore, mutation } from '../store'
+import { gameState, mutation } from '../store'
 
 const v = new THREE.Vector3()
 const m = new THREE.Matrix4()
@@ -9,7 +9,6 @@ const o = new THREE.Object3D()
 const q = new THREE.Quaternion()
 
 export function Dust({ opacity = 0.1, length = 200, size = 1 }) {
-  const { wheels } = useStore((state) => state.raycast)
   const trail = useRef()
 
   let i = 0
@@ -18,14 +17,14 @@ export function Dust({ opacity = 0.1, length = 200, size = 1 }) {
   let intensity = 0
   let ctrl
   useFrame((state, delta) => {
-    ctrl = useStore.getState().controls
+    ctrl = gameState.controls
     intensity = THREE.MathUtils.lerp(intensity, ((mutation.sliding || ctrl.brake) * mutation.speed) / 40, delta * 8)
 
     if (state.clock.getElapsedTime() - time > 0.02) {
       time = state.clock.getElapsedTime()
       // Set new trail
-      setItemAt(trail, wheels[2].current, index++, intensity)
-      setItemAt(trail, wheels[3].current, index++, intensity)
+      setItemAt(trail, gameState.raycast.wheels[2].current, index++, intensity)
+      setItemAt(trail, gameState.raycast.wheels[3].current, index++, intensity)
       if (index === length) index = 0
     } else {
       // Shrink old one

--- a/src/effects/Skid.jsx
+++ b/src/effects/Skid.jsx
@@ -1,17 +1,16 @@
 import * as THREE from 'three'
 import { useRef, useLayoutEffect } from 'react'
 import { useFrame } from '@react-three/fiber'
-import { useStore, mutation } from '../store'
+import { gameState, mutation } from '../store'
 
 const o = new THREE.Object3D()
 
 export function Skid({ opacity = 0.5, length = 500, size = 0.4 }) {
   const ref = useRef()
-  const { wheels, chassisBody } = useStore((state) => state.raycast)
 
   function setItemAt(obj, i) {
     o.position.set(obj.position.x, obj.position.y - 0, obj.position.z)
-    o.rotation.copy(chassisBody.current.rotation)
+    o.rotation.copy(gameState.raycast.chassisBody.current.rotation)
     o.scale.setScalar(1)
     o.updateMatrix()
     ref.current.setMatrixAt(i, o.matrix)
@@ -21,10 +20,10 @@ export function Skid({ opacity = 0.5, length = 500, size = 0.4 }) {
   let ctrl
   let index = 0
   useFrame(() => {
-    ctrl = useStore.getState().controls
+    ctrl = gameState.controls
     if (ctrl.brake && mutation.speed > 10) {
-      setItemAt(wheels[2].current, index++)
-      setItemAt(wheels[3].current, index++)
+      setItemAt(gameState.raycast.wheels[2].current, index++)
+      setItemAt(gameState.raycast.wheels[3].current, index++)
       if (index === length) index = 0
     }
   })

--- a/src/models/Goal.js
+++ b/src/models/Goal.js
@@ -1,8 +1,7 @@
 import { useBox } from '@react-three/cannon'
-import { mutation, useStore } from '../store'
+import { mutation, gameState } from '../store'
 
 export function Goal({ start, args = [1, 1, 1], ...props }) {
-  const set = useStore((state) => state.set)
   const onCollide = () => {
     if (start) {
       mutation.start = Date.now()
@@ -10,7 +9,7 @@ export function Goal({ start, args = [1, 1, 1], ...props }) {
     } else {
       mutation.finish = Date.now()
       const time = !mutation.start && !mutation.finish ? 0 : mutation.finish ? mutation.finish - mutation.start : Date.now() - mutation.start
-      set({ finished: time })
+      gameState.finished = time
     }
   }
   useBox(() => ({ isTrigger: true, args, userData: { trigger: true }, onCollide, ...props }), undefined, [args, props])

--- a/src/models/track/Track.jsx
+++ b/src/models/track/Track.jsx
@@ -5,16 +5,17 @@ import * as THREE from 'three'
 import { useLayoutEffect, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { MeshDistortMaterial, useGLTF, PositionalAudio } from '@react-three/drei'
-import { useStore, levelLayer } from '../../store'
+import { useSnapshot } from 'valtio'
+import { gameState, levelLayer } from '../../store'
 
 export function Track(props) {
-  const [ready, level, sound] = useStore((state) => [state.ready, state.level, state.sound])
+  const { ready, level, sound } = useSnapshot(gameState)
   const { nodes: n, materials: m } = useGLTF('/models/track-draco.glb')
   const config = { receiveShadow: true, castShadow: true, 'material-roughness': 1 }
   const birds = useRef()
   const clouds = useRef()
 
-  useLayoutEffect(() => void level.current.traverse((child) => child.layers.enable(levelLayer)), [])
+  useLayoutEffect(() => void gameState.level.current.traverse((child) => child.layers.enable(levelLayer)), [])
   useFrame((state, delta) => {
     birds.current.children.forEach((bird, index) => (bird.rotation.y += delta / index))
     clouds.current.children.forEach((bird, index) => (bird.rotation.y += delta / 25 / index))

--- a/src/models/track/Train.jsx
+++ b/src/models/track/Train.jsx
@@ -2,11 +2,12 @@ import { useLayoutEffect, useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 import { useGLTF, useAnimations, PositionalAudio } from '@react-three/drei'
 import { useBox } from '@react-three/cannon'
-import { useStore } from '../../store'
+import { useSnapshot } from 'valtio'
+import { gameState } from '../../store'
 
 export function Train({ args = [38, 8, 10], position = [-145.84, 3.42, 54.67], rotation = [0, -0.09, 0] }) {
   const group = useRef()
-  const [ready, sound] = useStore((state) => [state.ready, state.sound])
+  const { ready, sound } = useSnapshot(gameState)
   const { animations, nodes: n, materials: m } = useGLTF('/models/track-draco.glb')
   const [, api] = useBox(() => ({ mass: 10000, type: 'Kinematic', args, position, rotation }), undefined, [args, position, rotation])
   const { actions } = useAnimations(animations, group)

--- a/src/models/vehicle/Chassis.jsx
+++ b/src/models/vehicle/Chassis.jsx
@@ -9,7 +9,7 @@ import { useGLTF, PositionalAudio } from '@react-three/drei'
 import { useBox } from '@react-three/cannon'
 import debounce from 'lodash-es/debounce'
 import clamp from 'lodash-es/clamp'
-import { useStore, mutation } from '../../store'
+import { gameState, mutation } from '../../store'
 
 const c = new THREE.Color()
 export const Chassis = forwardRef(({ args = [2, 1.1, 4.7], mass = 500, children, ...props }, ref) => {
@@ -18,11 +18,10 @@ export const Chassis = forwardRef(({ args = [2, 1.1, 4.7], mass = 500, children,
   const wheel = useRef()
   const needle = useRef()
   const crashAudio = useRef()
-  const [ready, camera, vehicleConfig] = useStore((s) => [s.ready, s.camera, s.vehicleConfig])
   const { nodes: n, materials: m } = useGLTF('/models/chassis-draco.glb')
   const onCollide = useCallback(
     debounce((e) => {
-      if (e.body.userData.trigger || !useStore.getState().sound) return
+      if (e.body.userData.trigger || !gameState.sound) return
       crashAudio.current?.setVolume(clamp(e.contact.impactVelocity / 10, 0.2, 1))
       if (!crashAudio.current?.isPlaying) crashAudio.current?.play()
     }, 200),
@@ -33,14 +32,14 @@ export const Chassis = forwardRef(({ args = [2, 1.1, 4.7], mass = 500, children,
   let ctrl
   useFrame((_, delta) => {
     speed = mutation.speed
-    ctrl = useStore.getState().controls
+    ctrl = gameState.controls
     brake.current.material.color.lerp(c.set(ctrl.brake ? '#555' : 'white'), delta * 10)
     brake.current.material.emissive.lerp(c.set(ctrl.brake ? 'red' : 'red'), delta * 10)
     brake.current.material.opacity = THREE.MathUtils.lerp(brake.current.material.opacity, ctrl.brake ? 1 : 0.3, delta * 10)
-    glass.current.material.opacity = THREE.MathUtils.lerp(glass.current.material.opacity, camera === 'FIRST_PERSON' ? 0.1 : 0.75, delta)
-    glass.current.material.color.lerp(c.set(camera === 'FIRST_PERSON' ? 'white' : 'black'), delta)
+    glass.current.material.opacity = THREE.MathUtils.lerp(glass.current.material.opacity, gameState.camera === 'FIRST_PERSON' ? 0.1 : 0.75, delta)
+    glass.current.material.color.lerp(c.set(gameState.camera === 'FIRST_PERSON' ? 'white' : 'black'), delta)
     wheel.current.rotation.z = THREE.MathUtils.lerp(wheel.current.rotation.z, ctrl.left ? -Math.PI : ctrl.right ? Math.PI : 0, delta)
-    needle.current.rotation.y = (speed / vehicleConfig.maxSpeed) * -Math.PI * 2 - 0.9
+    needle.current.rotation.y = (speed / gameState.vehicleConfig.maxSpeed) * -Math.PI * 2 - 0.9
   })
 
   return (
@@ -85,7 +84,7 @@ export const Chassis = forwardRef(({ args = [2, 1.1, 4.7], mass = 500, children,
         />
       </group>
       {children}
-      {ready && <PositionalAudio ref={crashAudio} url="/sounds/crash.mp3" loop={false} distance={5} />}
+      {gameState.ready && <PositionalAudio ref={crashAudio} url="/sounds/crash.mp3" loop={false} distance={5} />}
     </group>
   )
 })

--- a/src/models/vehicle/Wheel.jsx
+++ b/src/models/vehicle/Wheel.jsx
@@ -1,13 +1,19 @@
 import { forwardRef } from 'react'
 import { useGLTF } from '@react-three/drei'
 import { useCylinder } from '@react-three/cannon'
-import { useStore } from '../../store'
+import { useSnapshot } from 'valtio'
+import { gameState } from '../../store'
 
+// eslint-plugin-valtio doesn't support forwardRef.
+/* eslint-disable valtio/state-snapshot-rule */
 export const Wheel = forwardRef(({ leftSide, ...props }, ref) => {
-  const { radius } = useStore((state) => state.vehicleConfig)
   const { nodes, materials } = useGLTF('/models/wheel-draco.glb')
+  const { radius } = useSnapshot(gameState)
   const scale = radius / 0.34
-  useCylinder(() => ({ mass: 50, type: 'Kinematic', material: 'wheel', collisionFilterGroup: 0, args: [radius, radius, 0.5, 16], ...props }), ref)
+  useCylinder(
+    () => ({ mass: 50, type: 'Kinematic', material: 'wheel', collisionFilterGroup: 0, args: [gameState.radius, gameState.radius, 0.5, 16], ...props }),
+    ref,
+  )
   return (
     <group ref={ref} dispose={null}>
       <group scale={scale}>

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,5 @@
 import { createRef } from 'react'
-import create from 'zustand'
-import shallow from 'zustand/shallow'
+import { proxy, ref } from 'valtio'
 
 export const angularVelocity = [0, 0.5, 0]
 export const cameras = ['DEFAULT', 'FIRST_PERSON', 'BIRD_EYE']
@@ -58,42 +57,38 @@ const wheelInfos = [
   },
 ]
 
-const useStoreImpl = create((set, get) => {
-  return {
-    set,
-    get,
-    dpr: 1.5,
-    shadows: true,
-    camera: cameras[0],
-    ready: false,
-    editor: false,
-    finished: false,
-    help: false,
-    leaderboard: false,
-    debug: false,
-    stats: false,
-    sound: true,
-    level: createRef(),
-    map: true,
-    raycast: {
-      chassisBody: createRef(),
-      wheels: [createRef(), createRef(), createRef(), createRef()],
-      wheelInfos,
-      indexForwardAxis: 2,
-      indexRightAxis: 0,
-      indexUpAxis: 1,
-    },
-    controls: {
-      forward: false,
-      backward: false,
-      left: false,
-      right: false,
-      brake: false,
-      honk: false,
-      boost: false,
-    },
-    vehicleConfig,
-  }
+export const gameState = proxy({
+  dpr: 1.5,
+  shadows: true,
+  camera: cameras[0],
+  ready: false,
+  editor: false,
+  finished: false,
+  help: false,
+  leaderboard: false,
+  debug: false,
+  stats: false,
+  sound: true,
+  level: ref(createRef()),
+  map: true,
+  raycast: ref({
+    chassisBody: createRef(),
+    wheels: [createRef(), createRef(), createRef(), createRef()],
+    wheelInfos,
+    indexForwardAxis: 2,
+    indexRightAxis: 0,
+    indexUpAxis: 1,
+  }),
+  controls: {
+    forward: false,
+    backward: false,
+    left: false,
+    right: false,
+    brake: false,
+    honk: false,
+    boost: false,
+  },
+  vehicleConfig,
 })
 
 export const mutation = {
@@ -105,21 +100,14 @@ export const mutation = {
   sliding: false,
 }
 
-export const reset = (set) =>
-  set((state) => {
-    mutation.start = 0
-    mutation.finish = 0
+export const reset = () => {
+  mutation.start = 0
+  mutation.finish = 0
 
-    state.raycast.chassisBody.current.api.position.set(...position)
-    state.raycast.chassisBody.current.api.velocity.set(0, 0, 0)
-    state.raycast.chassisBody.current.api.angularVelocity.set(...angularVelocity)
-    state.raycast.chassisBody.current.api.rotation.set(...rotation)
+  gameState.raycast.chassisBody.current.api.position.set(...position)
+  gameState.raycast.chassisBody.current.api.velocity.set(0, 0, 0)
+  gameState.raycast.chassisBody.current.api.angularVelocity.set(...angularVelocity)
+  gameState.raycast.chassisBody.current.api.rotation.set(...rotation)
 
-    return { ...state, finished: false }
-  })
-
-// Make the store shallow compare by default
-const useStore = (sel) => useStoreImpl(sel, shallow)
-Object.assign(useStore, useStoreImpl)
-
-export { useStore }
+  gameState.finished = false
+}

--- a/src/ui/Editor.js
+++ b/src/ui/Editor.js
@@ -1,10 +1,9 @@
 import { useControls, folder } from 'leva'
-import { useStore, vehicleConfig, wheelInfo } from '../store'
+import { gameState, vehicleConfig, wheelInfo } from '../store'
 
 const { directionLocal, axleLocal, chassisConnectionPointLocal, rollInfluence, ...filteredWheelInfo } = wheelInfo
 
 export function Editor() {
-  const [get, set, raycast] = useStore((state) => [state.get, state.set, state.raycast])
   const { radius, width, height, front, back, steer, force, maxBrake, maxSpeed } = vehicleConfig
   const {
     suspensionStiffness,
@@ -14,12 +13,12 @@ export function Editor() {
     suspensionForce,
     frictionSlip,
     sideAcceleration,
-  } = raycast.wheelInfos[0]
+  } = gameState.raycast.wheelInfos[0] // this is not reactive
 
   const [, setVehicleEditor] = useControls(() => ({
     Performance: folder({
-      shadows: { value: true, onChange: (shadows) => set({ shadows }) },
-      dpr: { value: 1.5, min: 1, max: 2, step: 0.5, onChange: (dpr) => set({ dpr }) },
+      shadows: { value: true, onChange: (shadows) => void (gameState.shadows = shadows) },
+      dpr: { value: 1.5, min: 1, max: 2, step: 0.5, onChange: (dpr) => void (gameState.dpr = dpr) },
     }),
     Vehicle: folder(
       {
@@ -28,119 +27,97 @@ export function Editor() {
           min: 0.1,
           max: 2,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              vehicleConfig: { ...get().vehicleConfig, radius: value },
-              raycast: { ...get().raycast, wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, radius: value })) },
-            }),
+          onChange: (value) => {
+            gameState.vehicleConfig.radius = value
+            gameState.raycast.wheelInfos[0].radius = value
+            gameState.raycast.wheelInfos[1].radius = value
+            gameState.raycast.wheelInfos[2].radius = value
+            gameState.raycast.wheelInfos[3].radius = value
+          },
         },
         width: {
           value: width,
           min: 0.1,
           max: 10,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              vehicleConfig: { ...get().vehicleConfig, width: value },
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({
-                  ...info,
-                  chassisConnectionPointLocal: [
-                    info.chassisConnectionPointLocal[0] < 0 ? -value / 2 : value / 2,
-                    info.chassisConnectionPointLocal[1],
-                    info.chassisConnectionPointLocal[2],
-                  ],
-                })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.vehicleConfig.width = value
+            for (let i = 0; i < 4; ++i) {
+              gameState.raycast.wheelInfos[i].chassisConnectionPointLocal[0] =
+                gameState.raycast.wheelInfos[0].chassisConnectionPointLocal[0] < 0 ? -value / 2 : value / 2
+            }
+          },
         },
         height: {
           value: height,
           min: -5,
           max: 5,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              vehicleConfig: { ...get().vehicleConfig, height: value },
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({
-                  ...info,
-                  chassisConnectionPointLocal: [info.chassisConnectionPointLocal[0], value, info.chassisConnectionPointLocal[2]],
-                })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.vehicleConfig.height = value
+            gameState.raycast.wheelInfos[0].chassisConnectionPointLocal[1] = value
+            gameState.raycast.wheelInfos[1].chassisConnectionPointLocal[1] = value
+            gameState.raycast.wheelInfos[2].chassisConnectionPointLocal[1] = value
+            gameState.raycast.wheelInfos[3].chassisConnectionPointLocal[1] = value
+          },
         },
         front: {
           value: front,
           min: -10,
           max: 10,
           step: 0.05,
-          onChange: (value) =>
-            set({
-              vehicleConfig: { ...get().vehicleConfig, front: value },
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info, index) => ({
-                  ...info,
-                  chassisConnectionPointLocal: [
-                    info.chassisConnectionPointLocal[0],
-                    info.chassisConnectionPointLocal[1],
-                    index < 2 ? value : info.chassisConnectionPointLocal[2],
-                  ],
-                })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.vehicleConfig.front = value
+            gameState.raycast.wheelInfos[0].chassisConnectionPointLocal[2] = value
+            gameState.raycast.wheelInfos[1].chassisConnectionPointLocal[2] = value
+          },
         },
         back: {
           value: back,
           min: -10,
           max: 10,
           step: 0.05,
-          onChange: (value) =>
-            set({
-              vehicleConfig: { ...get().vehicleConfig, back: value },
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info, index) => ({
-                  ...info,
-                  chassisConnectionPointLocal: [
-                    info.chassisConnectionPointLocal[0],
-                    info.chassisConnectionPointLocal[1],
-                    index < 2 ? info.chassisConnectionPointLocal[2] : value,
-                  ],
-                })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.vehicleConfig.back = value
+            gameState.raycast.wheelInfos[0].chassisConnectionPointLocal[2] = value
+            gameState.raycast.wheelInfos[1].chassisConnectionPointLocal[2] = value
+          },
         },
         steer: {
           value: steer,
           min: 0.1,
           max: 1,
           step: 0.01,
-          onChange: (value) => set({ vehicleConfig: { ...get().vehicleConfig, steer: value } }),
+          onChange: (value) => {
+            gameState.vehicleConfig.steer = value
+          },
         },
         force: {
           value: force,
           min: 0,
           max: 3000,
           step: 1,
-          onChange: (value) => set({ vehicleConfig: { ...get().vehicleConfig, force: value } }),
+          onChange: (value) => {
+            gameState.vehicleConfig.force = value
+          },
         },
         maxBrake: {
           value: maxBrake,
           min: 0.1,
           max: 100,
           step: 0.01,
-          onChange: (value) => set({ vehicleConfig: { ...get().vehicleConfig, maxBrake: value } }),
+          onChange: (value) => {
+            gameState.vehicleConfig.maxBrake = value
+          },
         },
         maxSpeed: {
           value: maxSpeed,
           min: 1,
           max: 150,
           step: 1,
-          onChange: (value) => set({ vehicleConfig: { ...get().vehicleConfig, maxSpeed: value } }),
+          onChange: (value) => {
+            gameState.vehicleConfig.maxSpeed = value
+          },
         },
       },
       { collapsed: true },
@@ -152,88 +129,81 @@ export function Editor() {
           min: 0,
           max: 500,
           step: 1,
-          onChange: (value) =>
-            set({
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, suspensionStiffness: value })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.raycast.wheelInfos[0].suspensionStiffness = value
+            gameState.raycast.wheelInfos[1].suspensionStiffness = value
+            gameState.raycast.wheelInfos[2].suspensionStiffness = value
+            gameState.raycast.wheelInfos[3].suspensionStiffness = value
+          },
         },
         suspensionRestLength: {
           value: suspensionRestLength,
           min: -10,
           max: 10,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, suspensionRestLength: value })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.raycast.wheelInfos[0].suspensionRestLength = value
+            gameState.raycast.wheelInfos[1].suspensionRestLength = value
+            gameState.raycast.wheelInfos[2].suspensionRestLength = value
+            gameState.raycast.wheelInfos[3].suspensionRestLength = value
+          },
         },
         useCustomSlidingRotationalSpeed: {
           value: useCustomSlidingRotationalSpeed,
-          onChange: (value) =>
-            set({
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, useCustomSlidingRotationalSpeed: value })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.raycast.wheelInfos[0].useCustomSlidingRotationalSpeed = value
+            gameState.raycast.wheelInfos[1].useCustomSlidingRotationalSpeed = value
+            gameState.raycast.wheelInfos[2].useCustomSlidingRotationalSpeed = value
+            gameState.raycast.wheelInfos[3].useCustomSlidingRotationalSpeed = value
+          },
         },
         customSlidingRotationalSpeed: {
           value: customSlidingRotationalSpeed,
           min: -10,
           max: 10,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, customSlidingRotationalSpeed: value })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.raycast.wheelInfos[0].customSlidingRotationalSpeed = value
+            gameState.raycast.wheelInfos[1].customSlidingRotationalSpeed = value
+            gameState.raycast.wheelInfos[2].customSlidingRotationalSpeed = value
+            gameState.raycast.wheelInfos[3].customSlidingRotationalSpeed = value
+          },
         },
         suspensionForce: {
           value: suspensionForce,
           min: 0,
           max: 500,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, suspensionForce: value })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.raycast.wheelInfos[0].suspensionForce = value
+            gameState.raycast.wheelInfos[1].suspensionForce = value
+            gameState.raycast.wheelInfos[2].suspensionForce = value
+            gameState.raycast.wheelInfos[3].suspensionForce = value
+          },
         },
         frictionSlip: {
           value: frictionSlip,
           min: -10,
           max: 10,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, frictionSlip: value })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.raycast.wheelInfos[0].frictionSlip = value
+            gameState.raycast.wheelInfos[1].frictionSlip = value
+            gameState.raycast.wheelInfos[2].frictionSlip = value
+            gameState.raycast.wheelInfos[3].frictionSlip = value
+          },
         },
         sideAcceleration: {
           value: sideAcceleration,
           min: -10,
           max: 10,
           step: 0.01,
-          onChange: (value) =>
-            set({
-              raycast: {
-                ...get().raycast,
-                wheelInfos: get().raycast.wheelInfos.map((info) => ({ ...info, sideAcceleration: value })),
-              },
-            }),
+          onChange: (value) => {
+            gameState.raycast.wheelInfos[0].sideAcceleration = value
+            gameState.raycast.wheelInfos[1].sideAcceleration = value
+            gameState.raycast.wheelInfos[2].sideAcceleration = value
+            gameState.raycast.wheelInfos[3].sideAcceleration = value
+          },
         },
       },
       { collapsed: true },
@@ -244,8 +214,8 @@ export function Editor() {
           value: false,
           onChange: () => setVehicleEditor({ debug: false, reset: false, ...vehicleConfig, ...filteredWheelInfo }),
         },
-        stats: { value: false, onChange: (stats) => set({ stats }) },
-        debug: { value: false, onChange: (debug) => set({ debug }) },
+        stats: { value: false, onChange: (stats) => void (gameState.stats = stats) },
+        debug: { value: false, onChange: (debug) => void (gameState.debug = debug) },
       },
       { collapsed: true },
     ),

--- a/src/ui/Finished.jsx
+++ b/src/ui/Finished.jsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
-import { reset, useStore } from '../store'
+import { useSnapshot } from 'valtio'
+import { reset, gameState } from '../store'
 import { getScores, insertScore } from '../data'
 import { Score } from './LeaderBoard'
 
 export const Finished = () => {
   const LOCAL_STORAGE_KEY = 'racing-pmndrs-name'
   const [name, setName] = useState('')
-  const finished = useStore((state) => state.finished)
+  const { finished } = useSnapshot(gameState)
   const readableTime = (finished / 1000).toFixed(2)
   const [savedName, setSavedName] = useState(window.localStorage.getItem(LOCAL_STORAGE_KEY))
   const [scores, setScores] = useState(null)
@@ -62,9 +63,8 @@ export const Finished = () => {
 }
 
 const Restart = () => {
-  const set = useStore((state) => state.set)
   return (
-    <button className="restart" onClick={() => reset(set)}>
+    <button className="restart" onClick={() => reset()}>
       <div>Restart</div>
     </button>
   )

--- a/src/ui/Help.jsx
+++ b/src/ui/Help.jsx
@@ -1,4 +1,5 @@
-import { useStore } from '../store'
+import { useSnapshot } from 'valtio'
+import { gameState } from '../store'
 
 const controlOptions = [
   { keys: ['↑', 'W'], action: 'Forward' },
@@ -18,14 +19,14 @@ const controlOptions = [
 ]
 
 export function Help() {
-  const [set, help, sound] = useStore((state) => [state.set, state.help, state.sound])
+  const { help, sound } = useSnapshot(gameState)
   return (
     <>
       <div className={`${sound ? 'sound' : 'nosound'}`}></div>
       <div className="controls">
-        {!help && <button onClick={() => set({ help: true })}>i</button>}
+        {!help && <button onClick={() => void (gameState.help = true)}>i</button>}
         <div className={`popup ${help ? 'open' : ''}`}>
-          <button className="popup-close" onClick={() => set({ help: false })}>
+          <button className="popup-close" onClick={() => void (gameState.help = false)}>
             i
           </button>
           <div className="popup-content">

--- a/src/ui/Intro.jsx
+++ b/src/ui/Intro.jsx
@@ -2,7 +2,7 @@ import { Suspense, useEffect, useState } from 'react'
 import { Footer } from '@pmndrs/branding'
 import { useProgress } from '@react-three/drei'
 import { Keys } from './Help'
-import { useStore } from '../store'
+import { gameState } from '../store'
 
 function Ready({ setReady }) {
   useEffect(() => () => void setReady(true), [])
@@ -17,10 +17,11 @@ function Loader() {
 export function Intro({ children }) {
   const [ready, setReady] = useState(false)
   const [clicked, setClicked] = useState(false)
-  const set = useStore((state) => state.set)
 
   useEffect(() => {
-    if (clicked && ready) set({ ready: true })
+    if (clicked && ready) {
+      gameState.ready = true
+    }
   }, [ready, clicked])
 
   return (

--- a/src/ui/LeaderBoard.jsx
+++ b/src/ui/LeaderBoard.jsx
@@ -1,17 +1,22 @@
 import { useEffect, useState } from 'react'
+import { useSnapshot } from 'valtio'
 import { getScores } from '../data'
-import { useStore } from '../store'
+import { gameState } from '../store'
 
 export function LeaderBoard() {
   const [scores, setScores] = useState([])
   const [last, setLast] = useState(0)
-  const [set, leaderboard] = useStore((state) => [state.set, state.leaderboard])
+  const { leaderboard } = useSnapshot(gameState)
   useEffect(() => {
+    // this is false positive (no problem because leaderboard is boolean)
+    // eslint-disable-next-line valtio/state-snapshot-rule
     if (!leaderboard || Date.now() - last < 3000) return
     getScores(10).then(setScores)
     setLast(Date.now())
   }, [leaderboard])
-  const close = () => set((state) => ({ ...state, leaderboard: false }))
+  const close = () => {
+    gameState.leaderboard = false
+  }
   return (
     <div className="controls">
       <div className={`popup ${leaderboard ? 'open' : ''}`}>

--- a/src/ui/Minimap.jsx
+++ b/src/ui/Minimap.jsx
@@ -2,7 +2,7 @@ import { OrthographicCamera, useFBO, useTexture } from '@react-three/drei'
 import { createPortal, useFrame, useThree } from '@react-three/fiber'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Box3, Matrix4, Scene, Vector3 } from 'three'
-import { useStore, levelLayer } from '../store'
+import { gameState, levelLayer } from '../store'
 
 const m = new Matrix4()
 const v = new Vector3()
@@ -11,11 +11,10 @@ function useLevelGeometricProperties() {
   const [box] = useState(() => new Box3())
   const [center] = useState(() => new Vector3())
   const [dimensions] = useState(() => new Vector3())
-  const level = useStore((state) => state.level)
   useLayoutEffect(() => {
-    if (level.current) {
-      level.current.parent.updateWorldMatrix()
-      box.setFromObject(level.current)
+    if (gameState.level.current) {
+      gameState.level.current.parent.updateWorldMatrix()
+      box.setFromObject(gameState.level.current)
       box.getCenter(center)
       box.getSize(dimensions)
     }
@@ -58,11 +57,10 @@ export function Minimap({ size = 200 }) {
   const buffer = useFBO(size * 2, size * 2)
   const { gl, camera, scene, size: screenSize } = useThree()
   const [, levelCenter, levelDimensions] = useLevelGeometricProperties()
-  const chassisBody = useStore((state) => state.raycast.chassisBody)
   const screenPosition = useMemo(() => new Vector3(screenSize.width / 2 - size / 2 - 30, screenSize.height / 2 - size / 2 - 30, 0), [screenSize])
 
   useFrame(() => {
-    if (chassisBody.current) {
+    if (gameState.raycast.chassisBody.current) {
       gl.autoClear = true
       gl.render(scene, camera)
       m.copy(camera.matrix).invert()
@@ -70,7 +68,7 @@ export function Minimap({ size = 200 }) {
       player.current.quaternion.setFromRotationMatrix(m)
       gl.autoClear = false
       gl.clearDepth()
-      v.subVectors(chassisBody.current.position, levelCenter)
+      v.subVectors(gameState.raycast.chassisBody.current.position, levelCenter)
       player.current.position.set(screenPosition.x + (v.x / levelDimensions.x) * size, screenPosition.y - (v.z / levelDimensions.z) * size, 0)
       gl.render(virtualScene, miniMapCamera.current)
     }

--- a/src/ui/Speed.jsx
+++ b/src/ui/Speed.jsx
@@ -1,16 +1,15 @@
 import { useEffect, useRef } from 'react'
-import { useStore, mutation } from '../store'
+import { gameState, mutation } from '../store'
 
 export function Speed() {
   const textRef = useRef()
   const gaugeRef = useRef()
-  const maxSpeed = useStore((state) => state.vehicleConfig.maxSpeed)
   useEffect(() => {
     const interval = setInterval(() => {
       if (textRef.current !== null) {
         const computedSpeed = mutation.speed * 1.5
         textRef.current.innerText = computedSpeed.toFixed()
-        gaugeRef.current.setAttribute('offset', Math.max(1 - computedSpeed / maxSpeed, 0))
+        gaugeRef.current.setAttribute('offset', Math.max(1 - computedSpeed / gameState.vehicleConfig.maxSpeed, 0))
       }
     }, 100)
     return () => clearInterval(interval)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1141,6 +1141,11 @@ eslint-plugin-react@7.24.0:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-valtio@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-valtio/-/eslint-plugin-valtio-0.3.1.tgz#00770ab53ad97e5d6427f14036213fe45f47f55b"
+  integrity sha512-WeCV4bnZilwzjZ89uUSBeG/OMBc/2cjIYxJbjIs6Y6o70KxciXXA9rcVSzFQpO4iCEewiqYm35oqINQmxcu8+A==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -2143,6 +2148,11 @@ prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+proxy-compare@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-compare/-/proxy-compare-2.0.0.tgz#36f41114a25fcf359037308d12529183a9dc182c"
+  integrity sha512-xhJF1+vPCnu93QYva3Weii5ho1AeX5dsR/P5O7pzy9QLxeOgMSQNC8zDo0bGg9vtn61Pu5Qn+5w/Y8OSU5k+8g==
+
 punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -2676,6 +2686,13 @@ v8n@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/v8n/-/v8n-1.3.3.tgz#4e03782173f1ac6108370859319050470d72a1c9"
   integrity sha512-5w0/blXdz5idt+TJj72Vs69HcRYDARRWFami3bj7TLx8qvOVpyL3D3wdnXVrPLWvSApfVe2vBV54V16QYVlJnA==
+
+valtio@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/valtio/-/valtio-1.0.6.tgz#b316deea5537d254a141e2e5af1692d9eae2f60f"
+  integrity sha512-ylCis9IkcE7b92XjMb3ebdJgLvJEFJ2NjfuD01QNr98pVOhRa5WsW4LSykFgbO4W7ftrZtO8jN4svZL0XlD77w==
+  dependencies:
+    proxy-compare "2.0.0"
 
 vite-react-jsx@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This PR is to use valtio instead of zustand. It tries to keep the difference small for now.
We could organize actions and hooks in store.js in the future.
(I was originally hoping to use `useProxy` macro, but wasn't able to work with vite. not sure why.)