### PR TITLE
Remove types that start with I

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,29 @@
         "plugin:react/recommended",
         "eslint:recommended"
     ],
+    "overrides": [{
+        "extends": "plugin:@typescript-eslint/recommended",
+        "files": ["*.tsx", "*.ts"],
+        "parser": "@typescript-eslint/parser",
+        "parserOptions": {
+            "project": "tsconfig.json"
+        },
+        "plugins": ["@typescript-eslint"],
+        "rules": {
+            "@typescript-eslint/consistent-type-imports": "error",
+            "@typescript-eslint/explicit-module-boundary-types": "off",
+            "@typescript-eslint/no-non-null-assertion": "off",
+            "@typescript-eslint/no-unused-vars": ["error", { "ignoreRestSiblings": true }],
+            "@typescript-eslint/quotes": ["error", "single", {
+                "allowTemplateLiterals": true,
+                "avoidEscape": true
+            }],
+            "@typescript-eslint/semi": ["error", "never"]
+        }
+    },
+    {
+        "files": ["*.jsx", "*.js"]
+    }],
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true
@@ -18,51 +41,19 @@
     "plugins": [
         "react"
     ],
-    "rules": {        
+    "rules": {
+        "eol-last": ["error", "always"],
+        "no-debugger": "error",
         "no-unused-vars": ["error", { "ignoreRestSiblings": true }],
         "react/no-children-prop": 0,
         "react/display-name": 0,
         "react/prop-types": 0,
         "react/react-in-jsx-scope": 0,
-        "semi": ["error", "never"],
-        "no-debugger": "error",
-        "eol-last": ["error", "always"]
+        "semi": ["error", "never"]
     },
     "settings": {
         "react": {
             "version": "detect"
         }
-    },
-    "overrides": [{
-        "files": ["*.tsx", "*.ts"],
-        "parser": "@typescript-eslint/parser",
-        "extends": "plugin:@typescript-eslint/recommended",
-        "plugins": ["@typescript-eslint"],
-        "parserOptions": {
-            "project": "tsconfig.json"
-        },
-
-        "rules": {
-            "semi": "off",
-            "@typescript-eslint/semi": ["error", "never"],
-            "quotes": "off",
-            "@typescript-eslint/quotes": ["error", "single", {
-                "allowTemplateLiterals": true,
-                "avoidEscape": true
-            }],
-            "@typescript-eslint/consistent-type-imports": "error",
-            "@typescript-eslint/no-non-null-assertion": "off",
-            "@typescript-eslint/explicit-module-boundary-types": "off"
-
-            // "@typescript-eslint/array-type": ["error", {
-            //     "default": "array-simple"
-            // }],
-            // "@typescript-eslint/no-redeclare": "error",
-            // "@typescript-eslint/no-implied-eval": "error",
-            // "@typescript-eslint/switch-exhaustiveness-check": "error",
-        }
-    },
-    {
-        "files": ["*.jsx", "*.js"]
-    }]
+    }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,11 +26,11 @@ function DebugScene({ children }: { children: ReactNode }) {
 
 export function App() {
   const [light, setLight] = useState<DirectionalLight>()
-  const [shadows, dpr, camera, editor, map, finished, stats] = useStore((s) => [s.shadows, s.dpr, s.camera, s.editor, s.map, s.finished, s.stats])
+  const [camera, dpr, editor, finished, map, shadows, stats] = useStore((s) => [s.camera, s.dpr, s.editor, s.finished, s.map, s.shadows, s.stats])
 
   return (
     <Intro>
-      <Canvas mode="concurrent" dpr={[1, dpr]} shadows={shadows} camera={{ position: [0, 5, 15], fov: 50 }}>
+      <Canvas key={`${dpr}${shadows}`} mode="concurrent" dpr={[1, dpr]} shadows={shadows} camera={{ position: [0, 5, 15], fov: 50 }}>
         <fog attach="fog" args={['white', 0, 500]} />
         <Sky sunPosition={[100, 10, 100]} distance={1000} />
         <ambientLight layers={layers} intensity={0.1} />

--- a/src/store.ts
+++ b/src/store.ts
@@ -20,9 +20,13 @@ const controls = {
   right: false,
 }
 
+export const debug = false as const
+export const dpr = 1.5 as const
 export const levelLayer = 1 as const
 export const position = [-110, 0.75, 220] as const
 export const rotation = [0, Math.PI / 2 + 0.35, 0] as const
+export const shadows = true as const
+export const stats = false as const
 
 export const vehicleConfig = {
   radius: 0.38,
@@ -43,6 +47,7 @@ export const wheelInfo = {
   suspensionRestLength: 0.35,
   axleLocal: [-1, 0, 0],
   chassisConnectionPointLocal: [1, 0, 1],
+  isFrontWheel: false,
   useCustomSlidingRotationalSpeed: true,
   customSlidingRotationalSpeed: -0.01,
   rollInfluence: 0,
@@ -54,22 +59,20 @@ export const wheelInfo = {
 const wheelInfos: WheelInfos = [
   {
     ...wheelInfo,
-    isFrontWheel: true,
     chassisConnectionPointLocal: [-vehicleConfig.width / 2, vehicleConfig.height, vehicleConfig.front],
-  },
-  {
-    ...wheelInfo,
     isFrontWheel: true,
-    chassisConnectionPointLocal: [vehicleConfig.width / 2, vehicleConfig.height, vehicleConfig.front],
   },
   {
     ...wheelInfo,
-    isFrontWheel: false,
+    chassisConnectionPointLocal: [vehicleConfig.width / 2, vehicleConfig.height, vehicleConfig.front],
+    isFrontWheel: true,
+  },
+  {
+    ...wheelInfo,
     chassisConnectionPointLocal: [-vehicleConfig.width / 2, vehicleConfig.height, vehicleConfig.back],
   },
   {
     ...wheelInfo,
-    isFrontWheel: false,
     chassisConnectionPointLocal: [vehicleConfig.width / 2, vehicleConfig.height, vehicleConfig.back],
   },
 ]
@@ -80,27 +83,29 @@ export type Controls = typeof controls
 export interface CannonApi extends Mesh {
   api: WorkerApi
 }
+
+type Getter = GetState<IState>
+
 interface Raycast {
   chassisBody: MutableRefObject<CannonApi | null>
   wheels: [MutableRefObject<CannonApi | null>, MutableRefObject<CannonApi | null>, MutableRefObject<CannonApi | null>, MutableRefObject<CannonApi | null>]
   wheelInfos: WheelInfos
 }
 
-type IWheelInfos = typeof wheelInfo & { isFrontWheel: boolean }
-export type WheelInfos = IWheelInfos[]
-
 export type Setter = SetState<IState>
-export type Getter = GetState<IState>
 
-export interface IState {
-  set: Setter
-  get: Getter
+type VehicleConfig = typeof vehicleConfig
+type WheelInfo = typeof wheelInfo
+export type WheelInfos = WheelInfo[]
+
+interface IState {
   camera: Camera
   controls: Controls
   debug: boolean
   dpr: number
   editor: boolean
   finished: number
+  get: Getter
   help: boolean
   leaderboard: boolean
   level: MutableRefObject<unknown>
@@ -108,22 +113,22 @@ export interface IState {
   raycast: Raycast
   ready: boolean
   session: Session | null
+  set: Setter
   shadows: boolean
   sound: boolean
   stats: boolean
-  vehicleConfig: typeof vehicleConfig
+  vehicleConfig: VehicleConfig
 }
 
 const useStoreImpl = create<IState>((set: SetState<IState>, get: GetState<IState>) => {
   return {
-    set,
-    get,
     camera: cameras[0],
     controls,
-    debug: false,
-    dpr: 1.5,
+    debug,
+    dpr,
     editor: false,
     finished: 0,
+    get,
     help: false,
     leaderboard: false,
     level: createRef(),
@@ -138,9 +143,10 @@ const useStoreImpl = create<IState>((set: SetState<IState>, get: GetState<IState
     },
     ready: false,
     session: null,
-    shadows: true,
+    set,
+    shadows,
     sound: true,
-    stats: false,
+    stats,
     vehicleConfig,
   }
 })

--- a/src/ui/Editor.ts
+++ b/src/ui/Editor.ts
@@ -1,18 +1,27 @@
-import { useControls, folder } from 'leva'
-import { useStore, vehicleConfig, wheelInfo } from '../store'
+import { button, folder, useControls } from 'leva'
+import { debug, dpr, shadows, stats, useStore, vehicleConfig, wheelInfo } from '../store'
 
-const { ...filteredWheelInfo } = wheelInfo
+const { directionLocal, axleLocal, chassisConnectionPointLocal, rollInfluence, ...filteredWheelInfo } = wheelInfo
 
-type IFilteredWheel = typeof filteredWheelInfo
-type IVehicleConfig = typeof vehicleConfig
-
-interface VehicleEditorProps extends IFilteredWheel, IVehicleConfig {
-  debug: boolean
-  reset: boolean
+const initialValues = {
+  debug,
+  dpr,
+  shadows,
+  stats,
+  ...filteredWheelInfo,
+  ...vehicleConfig,
 }
 
 export function Editor() {
-  const [get, set, raycast] = useStore((state) => [state.get, state.set, state.raycast])
+  const [get, set, debug, dpr, raycast, shadows, stats] = useStore((state) => [
+    state.get,
+    state.set,
+    state.debug,
+    state.dpr,
+    state.raycast,
+    state.shadows,
+    state.stats,
+  ])
   const { radius, width, height, front, back, steer, force, maxBrake, maxSpeed } = vehicleConfig
   const {
     suspensionStiffness,
@@ -26,8 +35,8 @@ export function Editor() {
 
   const [, setVehicleEditor] = useControls(() => ({
     Performance: folder({
-      shadows: { value: true, onChange: (shadows) => set({ shadows }) },
-      dpr: { value: 1.5, min: 1, max: 2, step: 0.5, onChange: (dpr) => set({ dpr }) },
+      dpr: { value: dpr, min: 1, max: 2, step: 0.5, onChange: (dpr) => set({ dpr }) },
+      shadows: { value: shadows, onChange: (shadows) => set({ shadows }) },
     }),
     Vehicle: folder(
       {
@@ -248,15 +257,15 @@ export function Editor() {
     ),
     Debug: folder(
       {
-        reset: {
-          value: false,
-          onChange: () => (setVehicleEditor as (value: VehicleEditorProps) => void)({ debug: false, reset: false, ...vehicleConfig, ...filteredWheelInfo }),
-        },
-        stats: { value: false, onChange: (stats) => set({ stats }) },
-        debug: { value: false, onChange: (debug) => set({ debug }) },
+        debug: { value: debug, onChange: (debug) => set({ debug }) },
+        stats: { value: stats, onChange: (stats) => set({ stats }) },
       },
       { collapsed: true },
     ),
+    reset: button(() => {
+      // @ts-expect-error -- FIXME: types when using folders seem to be broken
+      setVehicleEditor(initialValues)
+    }),
   }))
   return null
 }


### PR DESCRIPTION
- [Editor] Make reset work on all values
- [Editor] Make reset a button instead of a checkbox
- [Editor] Fix performance buttons not function (key on canvas was important)
- [Editor] Split `leva` config up into multiple objects
- [ESLintRC] Alphabetize & cleanup options
- [Store] Cleanup wheelInfos
- [Store] Export initial values for Editor
- [Store] Alphabetize

It seems like there's a bug with `leva`'s type when using folders:
```
src/ui/Editor.ts:276:24 - error TS2559: Type '{ radius: number; width: number; height: number; front: number; back: number; steer: number; force: number; maxBrake: number; maxSpeed: number; suspensionStiffness: number; suspensionRestLength: number; ... 9 more ...; stats: false; }' has no properties in common with type '{ Performance?: any; Vehicle?: any; Suspension?: any; Debug?: any; }'.

276       setVehicleEditor({ ...initialValues })
                           ~~~~~~~~~~~~~~~~~~~~
```

Any ideas?
