### PR TITLE
Configure tsconfig.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 .env.test.local
 .env.production.local
 .eslintcache
+tsconfig.tsbuildinfo
 
 npm-debug.log*
 yarn-debug.log*

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "esModuleInterop": false,
+    // https://esbuild.github.io/content-types/#es-module-interop
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
@@ -16,5 +17,6 @@
     "jsx": "react-jsx",
     "types": ["vite/client"]
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["node_modues"],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "incremental": true,
   },
   "include": ["./src"],
   "exclude": ["node_modues"],


### PR DESCRIPTION
- Pretty much ensures that node_modules is under no circumstances being touched by typescipt.
- And ensures that we will have correct code that esbuild can use(https://esbuild.github.io/content-types/#es-module-interop)
- Enables incremental tsc, which is pretty much the same as caching. 