### PR TITLE
(bug): fix button overlaps on Finished/Leaderboard screen.

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -92,39 +92,51 @@ body {
 /* --------------- Leaderboard --------------- */
 
 .finished {
-  position: absolute;
-  z-index: 10;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  width: 100vw;
-  height: 100vh;
-  background: #101010;
+  align-items: center;
   display: flex;
   flex-direction: column;
+  height: 100%;
+  text-align: center;
+  background: #101010;
+  bottom: 0;
+  position: absolute;
+  width: 100vw;
+  z-index: 10;
+}
+
+.finished-header {
+  max-height: 120px;
+}
+
+.finished-leaderboard {
+  flex: 1;
+  overflow-y: scroll;
+}
+
+.finished-auth {
+  height: auto;
+}
+
+.finished-restart {
   align-items: center;
-  justify-content: center;
+  display: flex;
+  height: 60px;
 }
 
-.finished .add-me {
-  width: auto;
+.leaderboard-name img {
+  position: relative;
+  right: 2px;
+  margin-right: 2px;
 }
 
-.finished .restart {
-  position: fixed;
-  bottom: 40px;
-  width: auto;
-  background: transparent;
-  color: white;
+.leaderboard-bottom li {
+  margin-bottom: 10px;
+  text-align: center;
+  counter-increment: listCounter;
 }
 
-.leaderboard {
-  list-style: none;
-  padding: 0;
-  margin-top: 20px;
-  counter-reset: listCounter;
-  max-height: 70vh;
-  overflow: auto;
+.leaderboard b {
+  margin-right: 5px;
 }
 
 .leaderboard li {
@@ -141,22 +153,6 @@ body {
   counter-reset: listCounter;
   max-height: auto;
   overflow: auto;
-}
-
-.leaderboard-bottom li {
-  margin-bottom: 10px;
-  text-align: center;
-  counter-increment: listCounter;
-}
-
-.leaderboard-name img {
-  position: relative;
-  right: 2px;
-  margin-right: 2px;
-}
-
-.leaderboard b {
-  margin-right: 5px;
 }
 
 /* --------------- SPEEDOMETER --------------- */
@@ -303,8 +299,8 @@ body {
 }
 
 button {
-  width: 32px;
-  height: 32px;
+  min-width: 32px;
+  min-height: 32px;
   color: inherit;
   border: none;
   font: inherit;

--- a/src/ui/Finished.tsx
+++ b/src/ui/Finished.tsx
@@ -38,29 +38,37 @@ export const Finished = (): JSX.Element => {
 
   return (
     <div className="finished">
-      <h1>Good job! Your time was {readableTime(time)} seconds</h1>
-      <Scores className="leaderboard" scores={scores} />
-      {isAuthenticated ? (
-        <>
-          {scoreId ? (
-            position ? (
-              <h1>You are number #{position}</h1>
-            ) : null
-          ) : (
-            <>
-              <h2>You belong on our leaderboard, {name}! </h2>
-              <button onClick={sendScore} style={{ margin: '0 auto', width: 'auto' }} className="popup-item-key">
-                Add my score
-              </button>
-            </>
-          )}
-        </>
-      ) : (
-        <Auth />
-      )}
-      <button className="restart" onClick={reset}>
-        <div>Restart</div>
-      </button>
+      <div className="finished-header">
+        <h1>Good job! Your time was {readableTime(time)} seconds</h1>
+      </div>
+      <div className="finished-leaderboard">
+        <Scores className="leaderboard" scores={scores} />
+      </div>
+      <div className="finished-auth">
+        {isAuthenticated ? (
+          <>
+            {scoreId ? (
+              position ? (
+                <h1>You are number #{position}</h1>
+              ) : null
+            ) : (
+              <>
+                <h2>You belong on our leaderboard, {name}! </h2>
+                <button onClick={sendScore} style={{ margin: '0 auto', width: 'auto' }} className="popup-item-key">
+                  Add my score
+                </button>
+              </>
+            )}
+          </>
+        ) : (
+          <Auth />
+        )}
+      </div>
+      <div className="finished-restart">
+        <button className="restart-btn" onClick={reset}>
+          Restart
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
The Finish screen has a couple of button overlaps: `restart` and `add to my score`

Fixing it by adding a flexbox container and leaving the Scores area with dynamic height so it works in all different viewports.
Also moving the styles for the "finished" section to `src/styles/finished` for better CSS organization.
Hope it helps!
_
Thanks