### PR TITLE
Fix negative scores

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -30,6 +30,7 @@ export const getScores = (limit = 50): PromiseLike<SavedScore[]> =>
   client
     .from('scores')
     .select()
+    .gt('time', 1337)
     .limit(limit)
     .order('time')
     .then(({ data }) => data || [])

--- a/src/store.ts
+++ b/src/store.ts
@@ -120,7 +120,7 @@ const useStoreImpl = create<IState>((set: SetState<IState>, get: GetState<IState
     onFinish: () => {
       const { finished, start } = get()
       if (start && !finished) {
-        set({ finished: Date.now() - start })
+        set({ finished: Math.max(Date.now() - start, 0) })
       }
     },
     onStart: () => {


### PR DESCRIPTION
Fixes #192

- `finished` must be a positive number
- do not display negative scores