### PR TITLE
Use reactDOMClient.createRoot().render for React 18 features

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { useGLTF, useTexture } from '@react-three/drei'
 import 'inter-ui'
 import './styles.css'
@@ -9,4 +9,4 @@ useGLTF.preload('/models/track-draco.glb')
 useGLTF.preload('/models/chassis-draco.glb')
 useGLTF.preload('/models/wheel-draco.glb')
 
-ReactDOM.render(<App />, document.getElementById('root'))
+createRoot(document.getElementById('root')!).render(<App />)

--- a/src/styles.css
+++ b/src/styles.css
@@ -352,19 +352,19 @@ button {
   margin: 10px auto;
 }
 
-.fullscreen .continue-link {
+.fullscreen .start-link {
   text-decoration: none;
   transition: all 1s;
   width: 20%;
   text-align: center;
 }
 
-.fullscreen.notready .continue-link {
+.fullscreen.loading .start-link {
   cursor: auto;
   color: #606060;
 }
 
-.fullscreen.ready .continue-link {
+.fullscreen.loaded .start-link {
   cursor: pointer;
   color: white;
 }

--- a/src/ui/Intro.tsx
+++ b/src/ui/Intro.tsx
@@ -2,33 +2,26 @@ import { Suspense, useEffect, useState } from 'react'
 import { Footer } from '@pmndrs/branding'
 import { useProgress } from '@react-three/drei'
 
-import type { Dispatch, FC, SetStateAction } from 'react'
+import type { FC } from 'react'
 
 import { useStore } from '../store'
 import { setupSession, unAuthenticateUser } from '../data'
 import { Keys } from './Help'
 import { Auth } from './Auth'
 
-type ReadyProps = { setReady: Dispatch<SetStateAction<boolean>> }
-
-const Ready: FC<ReadyProps> = ({ setReady }) => {
-  useEffect(() => () => setReady(true))
-  return null
-}
-
-const Loader: FC = () => {
-  const { progress } = useProgress()
-  return <div>loading {progress.toFixed()} %</div>
-}
-
 export const Intro: FC = ({ children }) => {
-  const [ready, setReady] = useState(false)
   const [clicked, setClicked] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const { progress } = useProgress()
   const [session, set] = useStore((state) => [state.session, state.set])
 
   useEffect(() => {
-    if (clicked && ready) set({ ready: true })
-  }, [ready, clicked])
+    if (clicked && !loading) set({ ready: true })
+  }, [clicked, loading])
+
+  useEffect(() => {
+    if (progress === 100) setLoading(false)
+  }, [progress])
 
   useEffect(() => {
     setupSession(set)
@@ -36,13 +29,13 @@ export const Intro: FC = ({ children }) => {
 
   return (
     <>
-      <Suspense fallback={<Ready setReady={setReady} />}>{children}</Suspense>
-      <div className={`fullscreen bg ${ready ? 'ready' : 'notready'} ${clicked && 'clicked'}`}>
+      <Suspense fallback={null}>{children}</Suspense>
+      <div className={`fullscreen bg ${loading ? 'loading' : 'loaded'} ${clicked && 'clicked'}`}>
         <div className="stack">
           <div className="intro-keys">
             <Keys style={{ paddingBottom: 20 }} />
-            <a className="continue-link" href="#" onClick={() => ready && setClicked(true)}>
-              {!ready ? <Loader /> : 'Click to continue'}
+            <a className="start-link" href="#" onClick={() => setClicked(true)}>
+              {loading ? `loading ${progress.toFixed()} %` : 'Click to start'}
             </a>
           </div>
           {session?.user?.aud !== 'authenticated' ? (


### PR DESCRIPTION
- Change `click to continue` to `click to start`
- Refactor `Intro` component as the `setReady` effect from `Ready` does not fire anymore
- Changed `ready` in `Intro` component to `loading`
