### PR TITLE
fixes #202; Fixing sound bug happening after used editor.

### DIFF
--- a/src/effects/Cameras.tsx
+++ b/src/effects/Cameras.tsx
@@ -3,7 +3,9 @@ import { useStore } from '../store'
 
 export function Cameras() {
   const [camera, editor] = useStore((state) => [state.camera, state.editor])
-  return (
+  return editor ? (
+    <OrthographicCamera makeDefault={editor} position={[0, 50, 0]} zoom={20} />
+  ) : (
     <>
       <PerspectiveCamera makeDefault={!editor && camera !== 'BIRD_EYE'} fov={75} rotation={[0, Math.PI, 0]} position={[0, 10, -20]} />
       <OrthographicCamera makeDefault={!editor && camera === 'BIRD_EYE'} position={[0, 100, 0]} rotation={[(-1 * Math.PI) / 2, 0, Math.PI]} zoom={15} />


### PR DESCRIPTION
#202 
Fixed by adding a default (Ortographic) camera view for the editor in the Camera.tsx. 
Without a default camera for the editor, the PositionalAudio class seemed to bug out. 